### PR TITLE
Add support ticket category

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/support-ticket.yml
+++ b/.github/DISCUSSION_TEMPLATE/support-ticket.yml
@@ -1,0 +1,1 @@
+bug-report.yml


### PR DESCRIPTION
When users run cw issue on version 0.14 it will open [aws/codewhisperer-command-line-discussions/discussions/new?category=support-ticket&title=](https://github.com/aws/codewhisperer-command-line-discussions/discussions/new?category=support-ticket&title=)